### PR TITLE
v3.1.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,10 @@
 # Changelog
+## [3.1.1] - 7/15/2024
+Fixes
+### Fixes
+- Fixed issue where commands that accepted a number argument were failing to parse the number correctly.
+- Fixed issue where `bed new item` was failing to automatically infer the `basic` type argument.
+---
 ## [3.1.0] - 7/9/2024
 Updates, Added Commands
 ### Updates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bedrock-development",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "APIs for creating and editing files related to Minecraft Bedrock development.",
   "main": "bin/index.js",
   "types": "bin/index.d.ts",

--- a/ts/app/commands/new/block.ts
+++ b/ts/app/commands/new/block.ts
@@ -3,6 +3,7 @@ import { Directories, File, copySourceFile, setFiles } from "../../file_manager.
 import { ClientBlocks, ClientGeometry, ClientTerrainTexture, Identifier, ServerAnimation, ServerBlock, ServerLootTable } from "../../types/index.js";
 import { LangFile } from "../../types/index.js";
 import { CommandMap } from "../command_map.js";
+import { Option } from "commander";
 
 export interface NewBlockOptions {
     lang: boolean;
@@ -20,7 +21,7 @@ CommandMap.addCommand<string[], NewBlockOptions>("root.new.block", {
         .description("creates new bedrock blocks")
         .argument("<names...>", 'block names as "namespace:block"')
         .option("--no-lang", "do not add lang file")
-        .option("-e, --emissive <emission>", "block emmission level [1-15]")
+        .addOption(new Option("-e, --emissive <emission>", "block emmission level [1-15]").argParser(parseInt))
         .option("-t, --table", "create a loot table")
         .option("-g, --geo", "create a custom geo")
         .option("-o, --override");

--- a/ts/app/commands/new/item.ts
+++ b/ts/app/commands/new/item.ts
@@ -31,13 +31,13 @@ CommandMap.addCommand<string[], NewItemOptions>("root.new.item", {
         .description("creates new bedrock items")
         .argument("<names...>", 'item names as "namespace:item"')
         .option("--no-lang", "do not add lang file")
-        .option("-s, --stack <stack_size>", "max stack size", "64")
+        .addOption(new Option("-s, --stack <stack_size>", "max stack size").default(64).argParser(parseInt))
         .option("-c, --cooldown <cooldown_duration>", "cooldown duration")
-        .option("-o, --override")
+        .option("-o, --override", "override existing files")
         .addOption(
-            new Option("-t, --type <item_type>", "basic").choices(
+            new Option("-t, --type <item_type>", "item type").choices(
                 Object.keys(ServerItemOptions)
-            )
+            ).default("basic")
         );
     },
     commandAction: triggerCreateNewItem,

--- a/ts/app/commands/world/new.ts
+++ b/ts/app/commands/world/new.ts
@@ -21,7 +21,7 @@ CommandMap.addCommand("root.world.new", {
 		.addArgument(new Argument("<name>", "the world name"))
 		.addOption(new Option("-t, --test", "create a test world with pre-configured gamerules"))
 		.addOption(new Option("-f, --flat", "create a flat world"))
-		.addOption(new Option("-m, --mode <gamemode>", "gamemode").choices(["0", "1", "2", "3"]))
+		.addOption(new Option("-m, --mode <gamemode>", "gamemode").choices(["0", "1", "2", "3"]).argParser(parseInt))
 		.addOption(new Option("-l, --local", "use the local packs in this workspace"))
 		.addOption(new Option("-b, --bpack <folder name>", "the name of the behavior pack to add"))
 		.addOption(new Option("-r, --rpack <folder name>", "the name of the resource pack to add"));


### PR DESCRIPTION
### Fixes
- Fixed issue where commands that accepted a number argument were failing to parse the number correctly.
- Fixed issue where `bed new item` was failing to automatically infer the `basic` type argument.